### PR TITLE
add option to start jboss

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,3 +12,4 @@ default['jboss-eap']['jboss_group'] = 'jboss'
 default['jboss-eap']['admin_user'] = nil
 default['jboss-eap']['admin_passwd'] = nil # Note the password has to be >= 8 characters, one numeric, one special
 default['jboss-eap']['start_on_boot'] = false
+default['jboss-eap']['start_on_converge'] = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -78,13 +78,18 @@ if node['jboss-eap']['admin_user'] && node['jboss-eap']['admin_passwd']
 	end
 end
 
+# Define the actions for the `jboss` service
+if node['jboss-eap']['start_on_boot']
+  action_array = [ :enable ]
+else
+  action_array = [ :disable ]
+end
 
+if node['jboss-eap']['start_on_converge']
+  action_array << :start
+end
 
-# Enable service on boot if requested
+# Start and Enable the jboss service on boot if requested
 service "jboss" do
-	if node['jboss-eap']['start_on_boot']
-		action :enable
-	else
-		action :disable
-	end
+  action action_array
 end


### PR DESCRIPTION
This PR adds an attribute to allow jboss to be started. Set to `false` by default not to break existing users of the cookbook. I didn't change the cookbook version.